### PR TITLE
Feat/a17 rewrite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -581,6 +581,16 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "http://npm.ooapi.com:4873/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -821,6 +831,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "http://npm.ooapi.com:4873/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -1075,6 +1091,12 @@
         }
       }
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "http://npm.ooapi.com:4873/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
@@ -1278,6 +1300,17 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "http://npm.ooapi.com:4873/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1451,6 +1484,17 @@
         "resolve": "^1.5.0",
         "umzug": "^2.3.0",
         "yargs": "^13.1.0"
+      }
+    },
+    "sequelize-mock": {
+      "version": "0.10.2",
+      "resolved": "http://npm.ooapi.com:4873/sequelize-mock/-/sequelize-mock-0.10.2.tgz",
+      "integrity": "sha1-GdOXHM2utbhkFwwkznkqinHxRL0=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.4.6",
+        "inflection": "^1.10.0",
+        "lodash": "^4.16.4"
       }
     },
     "sequelize-pool": {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "sequelize-cli": "^6.2.0",
     "sinon": "^9.2.0",
     "supertest": "^5.0.0"
+  },
+  "devDependencies": {
+    "proxyquire": "^2.1.3",
+    "sequelize-mock": "^0.10.2"
   }
 }

--- a/tests/A17.test.js
+++ b/tests/A17.test.js
@@ -1,0 +1,142 @@
+const chai = require('chai')
+const request = require('supertest')
+const sinon = require('sinon')
+const should = chai.should()
+const SequelizeMock = require('sequelize-mock');
+const proxyquire = require('proxyquire');
+
+const dbMock = new SequelizeMock();
+
+const app = require('../app');
+
+const mockRequest = (query) => {
+  return {
+    ...query,
+    flash: sinon.spy() 
+  };
+};
+const mockResponse = () => {
+  return {
+    redirect: sinon.spy()
+  }
+};
+
+describe('# A17', () => {
+  describe('登入測試: POST /signin', function(){
+    it('should fail without proper username', function(done){
+      request(app)
+        .post('/signin')
+        .type('urlencoded')
+        .send('email=root@example.com&password=123')
+        .expect('Location', '/signin')
+        .expect(302, done)
+    })
+
+    it('should fail without proper password', function(done){
+      request(app)
+        .post('/signin')
+        .type('urlencoded')
+        .send('email=tu&password=12345678')
+        .expect('Location', '/signin')
+        .expect(302, done)
+    })
+
+    it('should succeed with proper credentials', function(done){
+      request(app)
+        .post('/signin')
+        .type('urlencoded')
+        .send('email=root@example.com&password=12345678')
+        .expect('Location', '/')
+        .expect(302, done)
+    })
+  });
+
+  describe('# A17: 使用者權限管理', function () {
+    before(() => {
+      this.UserMock = dbMock.define('User', {
+        id: 1,
+        email: 'root@example.com',
+        name: 'admin',
+        isAdmin: false,
+      });
+      
+      this.adminController = proxyquire('../controllers/adminController', {
+        '../models': { User: this.UserMock }
+      }); 
+    })
+    
+    context('# [顯示使用者清單]', () => {
+      it(" GET /admin/users ", (done) => {
+        const req = {}
+        const res = {
+          render: (_, results) => {
+            results.users[0].name.should.equal("admin");
+            done()
+          }
+        };
+
+        this.adminController.getUsers(req, res);
+      });
+    })
+  
+    context('# [修改使用者權限] for admin', () => {
+      before(() => {
+        this.UserMock = dbMock.define('User', {
+          id: 1,
+          email: 'root@example.com',
+          name: 'admin',
+          isAdmin: false,
+        });
+        
+        this.adminController = proxyquire('../controllers/adminController', {
+          '../models': { User: this.UserMock }
+        }); 
+      })
+
+      it(" PUT /admin/users/:id/toggleAdmin ", async () => {
+        const req = mockRequest({params: {id: 1}});
+        const res = mockResponse();
+
+        await this.adminController.toggleAdmin(req, res);
+
+        req.flash.calledWith('error_messages', 'core manager can not be changed').should.be.true;
+        res.redirect.calledWith('back').should.be.true;
+      });
+    })
+
+    context('# [修改使用者權限] for user', () => {
+      before(() => {
+        this.UserMock = dbMock.define('User', {
+          id: 1,
+          email: 'user@example.com',
+          name: 'user',
+          isAdmin: false,
+        }, {
+          instanceMethods: {
+            update: (changes) => {
+              this.UserMock._defaults = {...changes};
+              return Promise.resolve();
+            }
+          }
+        });
+        
+        this.adminController = proxyquire('../controllers/adminController', {
+          '../models': { User: this.UserMock }
+        }); 
+      })
+
+      it(" PUT /admin/users/:id/toggleAdmin ", async () => {
+        const req = mockRequest({params: {id: 1}});
+        const res = mockResponse();
+
+        await this.adminController.toggleAdmin(req, res);
+
+        req.flash.calledWith('success_messages', 'user was successfully to update').should.be.true;
+        res.redirect.calledWith('/admin/users').should.be.true;
+
+        const user = await this.UserMock.findOne({where: {id: 1}});
+        user.isAdmin.should.equal(true);
+      });
+    })
+  })
+})


### PR DESCRIPTION
Add 2 lib
- proxyquire
- sequelize-mock

**Add login test, such as**
```
describe('登入測試: POST /signin', function(){
    it('should fail without proper username', function(done){
      request(app)
        .post('/signin')
        .type('urlencoded')
        .send('email=root@example.com&password=123')
        .expect('Location', '/signin')
        .expect(302, done)
    })
```

**Using sequelize mock to do the db query for testing**
```
   context('# [修改使用者權限] for user', () => {
      before(() => {
        this.UserMock = dbMock.define('User', {
          id: 1,
          email: 'user@example.com',
          name: 'user',
          isAdmin: false,
        }, {
          instanceMethods: {
            update: (changes) => {
              this.UserMock._defaults = {...changes};
              return Promise.resolve();
            }
          }
        });
        
        this.adminController = proxyquire('../controllers/adminController', {
          '../models': { User: this.UserMock }
        }); 
      })

      it(" PUT /admin/users/:id/toggleAdmin ", async () => {
        const req = mockRequest({params: {id: 1}});
        const res = mockResponse();

        await this.adminController.toggleAdmin(req, res);

        req.flash.calledWith('success_messages', 'user was successfully to update').should.be.true;
        res.redirect.calledWith('/admin/users').should.be.true;

        const user = await this.UserMock.findOne({where: {id: 1}});
        user.isAdmin.should.equal(true);
      });
    })
```